### PR TITLE
fix: remove release-drafter prerelease

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,5 @@
 name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
-prerelease-identifier: 'prerelease' # will create a prerelease with version number x.x.x-prerelease.x
+tag-template: 'v$RESOLVED_VERSION' # will create a prerelease with version number x.x.x-prerelease.x
 categories:
   - title: '🏆 Major:'
     labels:
@@ -19,7 +18,7 @@ categories:
   - title: '🩹 Patch:'
     labels:
       - 'patch'
-  - title: 'github-action:'
+  - title: '🤖 GitHub Action:'
     labels:
       - 'github-action'
   - title: '🪨 Dependencies:'
@@ -30,12 +29,13 @@ exclude-labels:
   - 'invalid'
   - 'duplicate'
   - 'wontfix'
-change-template: '- #$NUMBER $TITLE (@$AUTHOR)'
+change-template: '- $TITLE by @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:
     labels:
       - 'major'
+      - 'breaking change'
   minor:
     labels:
       - 'enhancement'
@@ -48,19 +48,18 @@ version-resolver:
       - 'github-action'
   default: patch
 template: |
-  ## v$RESOLVED_VERSION - $DATE
+  # What's Changed in v$RESOLVED_VERSION
 
   $CHANGES
 
-  Contributors:
-  $CONTRIBUTORS
+  ### Links
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/comapre/$PREVIOUS_TAG...$RESOLVED_VERSION
 
+  Current Tag: [$RESOLVED_VERSION](https://github.com/AdamJ/task-it/releases/tag/$RESOLVED_VERSION)
 
-  Previous Tag:
-  [$PREVIOUS_TAG](https://github.com/AdamJ/task-it/releases/tag/$PREVIOUS_TAG)
+  Previous Tag: [$PREVIOUS_TAG](https://github.com/AdamJ/task-it/releases/tag/$PREVIOUS_TAG)
 
   [All Tags](https://github.com/AdamJ/task-it/tags)
   [All Releases](https://github.com/AdamJ/task-it/releases)
-  [$OWNER](https://github.com/$OWNER)
 no-changes-template: |
   Nothing to see here...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -27,4 +27,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           publish: true
-          prerelease: true
+          prerelease: false

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ types
 gh-pages
 gh-pages.pub
 .env
+.secrets
+test-markdown.md

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-tracker",
-  "version": "0.21.0",
+  "version": "0.0.0",
   "homepage": "https://www.adamjolicoeur.me",
   "description": "Tracking games of Magic: The Gathering and other TCG scores.",
   "main": "index.js",


### PR DESCRIPTION
Made a mistake in adding the `prerelease` option to the release-labeler action. This removes that from the configuration.